### PR TITLE
docs: link product and API documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/magichourhq/magic-hour-go.svg)](https://pkg.go.dev/github.com/magichourhq/magic-hour-go)
 
-Magic Hour provides an API (beta) that can be integrated into your own application to generate videos and images using AI.
+The Magic Hour Go SDK provides convenient access to the [Magic Hour API](https://magichour.ai) for generating AI videos, images, and audio.
+
+For full API documentation, visit [docs.magichour.ai](https://docs.magichour.ai).
 
 Webhook documentation can be found [here](https://magichour.ai/docs/webhook).
 


### PR DESCRIPTION
## Summary

- identify the package explicitly as the Magic Hour Go SDK
- link the official Magic Hour product and API documentation from the README
- describe video, image, and audio generation support

## Why

Go modules derive package identity from the module path and Git tags rather than a package manifest. Direct README links and capability wording give developers and automated tools clear official product and documentation destinations.

## Developer impact

pkg.go.dev and repository visitors get direct paths to the product and full API documentation, with clear coverage of supported AI media types.

## Versioning

No source version field exists for a Go module. The next release should use the v0.74.3 tag.

## Validation

- `go test -p 1 ./...` — passed
- all linked URLs returned HTTP 200
